### PR TITLE
Bug squishing and enhancements

### DIFF
--- a/Random Appearance Button/Config/XComRandomAppearanceButton.ini
+++ b/Random Appearance Button/Config/XComRandomAppearanceButton.ini
@@ -16,11 +16,19 @@
 ; The button will select from each given prop by rolling a die between
 ; 0 and [LIMIT] where LIMIT is set below.
 ;
-; NOTE that, at this time, the Anarchy's Children arm decorations aren't
-; drawn on by the button.
-; E.G.
+; NOTE that, at this time, the Anarchy's Children (AC) arm decorations aren't
+; rolled by the Random Appearance button unless there's an AC torso rolled.
+; This is because AC torsos can't use the vanilla arms, so we're *forced*
+; to roll for AC arms. (The Totally Random does use AC torsos and arms with
+; nigh reckless abandon, of course.) So, if you want a chance at AC soldiers
+; here, just bump the TorsoRangeLimit up to include those torsos and you're
+; in business. (This will functionally ignore the ArmsRangeLimit by necessity
+; when rollling for AC DLC torsos.)
+;
+; Examples of use:
 ;		RABConf_HelmRangeLimit = 3 allows helmets 0 through 3.
 ;		RABConf_HelmRangeLimit = -1 allows ALL helmets.
+;		RABConf_TorsoRangeLimit = 5 will allow some AC DLC torsos.
 
 RABConf_HairRangeMaleLimit = 23
 RABConf_HairRangeFemaleLimit = 29

--- a/Random Appearance Button/Random Appearance Button.x2proj
+++ b/Random Appearance Button/Random Appearance Button.x2proj
@@ -18,9 +18,6 @@
     <Folder Include="Src\RandomAppearanceButton\Classes\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Config\Content.ini">
-      <SubType>Content</SubType>
-    </Content>
     <Content Include="Config\XComRandomAppearanceButton.ini">
       <SubType>Content</SubType>
     </Content>

--- a/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton.uc
+++ b/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton.uc
@@ -609,13 +609,18 @@ simulated function GenerateTotallyRandomAppearance(UIButton Button)
 	`log("TOTALRAND: Storing current appearance in undo buffer (if it's not there already).");
 	StoreAppearanceStateInUndoBuffer();
 
+	/*
+		Order of trait application matters: gender first (which we don't roll for) then
+		race (which seems to matter sometimes).
+	*/
+
 	// Core customization menu
+	RandomizeTrait(eUICustomizeCat_Race,				true);
 	RandomizeTrait(eUICustomizeCat_Face,				true);
 	RandomizeTrait(eUICustomizeCat_Hairstyle,			true);
 	RandomizeTrait(eUICustomizeCat_FacialHair,			true);
 	RandomizeTrait(eUICustomizeCat_HairColor,			true);
-	RandomizeTrait(eUICustomizeCat_EyeColor,			true);
-	RandomizeTrait(eUICustomizeCat_Race,				true);
+	RandomizeTrait(eUICustomizeCat_EyeColor,			true);	
 	RandomizeTrait(eUICustomizeCat_Skin,				true);
 	RandomizeTrait(eUICustomizeCat_PrimaryArmorColor,	true);
 	RandomizeTrait(eUICustomizeCat_SecondaryArmorColor,	true);
@@ -795,8 +800,7 @@ simulated function GenerateNormalLookingRandomAppearance(UIButton Button)
 		* Where DLC_1 is concerned, the DLC_1 torsos forbid the vanilla arms, so set THAT first, just incase.
 	*/
 
-	// For Sure do these.
-	// If we DID randomize on gender, that would go here.
+	// --> If we DID randomize on gender, that would go here, as it goes first. <--
 	RandomizeTrait(eUICustomizeCat_Race);
 	RandomizeTrait(eUICustomizeCat_Skin);
 
@@ -805,8 +809,10 @@ simulated function GenerateNormalLookingRandomAppearance(UIButton Button)
 
 	RandomizeTrait(eUICustomizeCat_Torso);
 	if ( class'RandomAppearanceButton_Utilities'.static.SoldierHasDLC1Torso(CustomizeMenuScreen) ) {
+		// No choice, can't use vanilla arms with DLC_1 arms.
 		RandomizeDLC1ArmSlots();
 	} else {
+		// This is a "normal looking" soldier, so, we want vanilla arms.
 		RandomizeTrait(eUICustomizeCat_Arms);
 	}
 	

--- a/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton.uc
+++ b/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton.uc
@@ -238,14 +238,14 @@ simulated function InitOptionsPanel()
 		Buttons on the panel.
 	*/
 
-	ToggleGenderButton	= CreateButton('ToggleGender',				"Switch Gender",		ToggleGender,	AnchorPos, -230, CHECKBOX_OFFSET_Y - BUTTON_HEIGHT - BUTTON_SPACING); // xoffset prev -154
+	ToggleGenderButton											= CreateButton('ToggleGender',			"Switch Gender",	ToggleGender,	AnchorPos, -230, CHECKBOX_OFFSET_Y - BUTTON_HEIGHT - BUTTON_SPACING);
 	ToggleGenderButton.SetDisabled(false, "Changing gender will clear the undo buffer.");
 	ToggleGenderButton.Hide();
 
-	CheckAllButton	= CreateButton('CheckAll',					"All",					CheckAll,		class'UIUtilities'.const.ANCHOR_BOTTOM_RIGHT, -154, -207);
+	CheckAllButton												= CreateButton('CheckAll',				"All",					CheckAll,		class'UIUtilities'.const.ANCHOR_BOTTOM_RIGHT, -154, -207);
 	CheckAllButton.Hide();
 
-	UncheckAllButton = CreateButton('UncheckAll',				"Clear",				UncheckAll,		class'UIUtilities'.const.ANCHOR_BOTTOM_RIGHT, -305, -207);
+	UncheckAllButton											= CreateButton('UncheckAll',			"Clear",				UncheckAll,		class'UIUtilities'.const.ANCHOR_BOTTOM_RIGHT, -305, -207);
 	UncheckAllButton.Hide();
 
 	/*
@@ -648,6 +648,9 @@ simulated function GenerateTotallyRandomAppearance(UIButton Button)
 	}
 	`log("DONE WITH ARMS.");
 
+	UpdateScreenData();
+	ResetTheCamera();
+
 	`log("TOTALRAND: Storing current appearance in undo buffer.");
 	StoreAppearanceStateInUndoBuffer();
 }
@@ -861,6 +864,9 @@ simulated function GenerateNormalLookingRandomAppearance(UIButton Button)
 		RandomizeTrait(eUICustomizeCat_EyeColor);
 	}
 
+	UpdateScreenData();
+	ResetTheCamera();
+
 	/*
 		Store the state we just created on the buffer as well. This is to support UNDO
 		for alterations via the normal UI
@@ -885,8 +891,9 @@ simulated function UndoAppearanceChanges(UIButton Button)
 	state up-to-date. Right now, manual changes (via the UI) aren't trackable by me,
 	but I *can* undo them IF one of the buttons has already been pressed.
 
-	People will be annoyed that they can't just UNDO vanilla changes, but what can
-	ya do?
+	If Firaxis fixes this, here's the breadcrumb to help me get back to a nice
+	Undo button that lights up and cools off when one can and can't undo, and even
+	tracks a counter of Undos in the buffer, as the prototype did.
 
 	`log("RANDMAIN: Rechecking Undo (to set correct button color state).");
 	if (!UndoBuffer.CanUndo()) {
@@ -897,8 +904,6 @@ simulated function UndoAppearanceChanges(UIButton Button)
 		UndoButtonLitUp();
 	}
 	*/
-
-	ResetTheCamera();
 }
 
 simulated function  ResetAndRandomize(EUICustomizeCategory eCategory)
@@ -995,7 +1000,6 @@ simulated function RandomizeTrait(EUICustomizeCategory eCategory, optional bool 
 		*/
 
 		SetTrait(eCategory, `SYNC_RAND(maxOptions));
-		ResetTheCamera();
 
 	} // endif (!bIsTraitLocked)
 }
@@ -1047,7 +1051,6 @@ private function ResetTheCamera()
 		becomes weird (locked, zoomed) otherwise.
 	*/
 
-	//CustomizeMenuScreen.CustomizeManager.UpdateCamera();
 	class'RandomAppearanceButton_Utilities'.static.ResetTheCamera(CustomizeMenuScreen);
 }
 

--- a/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton.uc
+++ b/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton.uc
@@ -649,7 +649,7 @@ simulated function GenerateTotallyRandomAppearance(UIButton Button)
 	`log("DONE WITH ARMS.");
 
 	UpdateScreenData();
-	ResetTheCamera();
+	ResetCamera();
 
 	`log("TOTALRAND: Storing current appearance in undo buffer.");
 	StoreAppearanceStateInUndoBuffer();
@@ -865,7 +865,7 @@ simulated function GenerateNormalLookingRandomAppearance(UIButton Button)
 	}
 
 	UpdateScreenData();
-	ResetTheCamera();
+	ResetCamera();
 
 	/*
 		Store the state we just created on the buffer as well. This is to support UNDO
@@ -1044,14 +1044,14 @@ simulated static function int GetTrait(UICustomize_Menu Screen, EUICustomizeCate
 	return Screen.CustomizeManager.GetCategoryIndex(eCategory);
 }
 
-private function ResetTheCamera()
+private function ResetCamera()
 {
 	/*
 		Calling this with no args helps correct the camera, which
 		becomes weird (locked, zoomed) otherwise.
 	*/
 
-	class'RandomAppearanceButton_Utilities'.static.ResetTheCamera(CustomizeMenuScreen);
+	class'RandomAppearanceButton_Utilities'.static.ResetCamera(CustomizeMenuScreen);
 }
 
 private function UpdateScreenData()

--- a/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton_UndoBuffer.uc
+++ b/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton_UndoBuffer.uc
@@ -55,7 +55,7 @@ var array<AppearanceState> Buffer;
 
 var UICustomize_Menu CustomizeMenuScreen;
 
-const MAX_UNDO_BUFFER_SIZE = 10;
+const MAX_UNDO_BUFFER_SIZE = 12;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton_UndoBuffer.uc
+++ b/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton_UndoBuffer.uc
@@ -499,6 +499,10 @@ simulated static function ApplyAppearanceSnapshot(const out UICustomize_Menu Scr
 		}
 
 	}
+
+	class'RandomAppearanceButton_Utilities'.static.UpdateScreenData(Screen);
+	class'RandomAppearanceButton_Utilities'.static.ResetCamera(Screen);
+
 }
 
 simulated function bool Undo()

--- a/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton_Utilities.uc
+++ b/Random Appearance Button/Src/RandomAppearanceButton/Classes/RandomAppearanceButton_Utilities.uc
@@ -216,7 +216,7 @@ simulated static function bool SoldierHasDLC1Arms(UICustomize_Menu CustomizeMenu
 	}
 }
 
-simulated static function ResetTheCamera(UICustomize_Menu Screen)
+simulated static function ResetCamera(UICustomize_Menu Screen)
 {
 	/*
 		Calling this with no args helps correct the camera, which


### PR DESCRIPTION
**Biggest change here is that I'm now calling ResetCamera only once per button click** instead of every single time a trait is rolled...which, in retrospect, makes way more sense. It really seems to have sped things up, as you might guess. (I'm a bit embarrassed that I missed this until now.)

Also fixed a bug where the vanilla UI wasn't updating to reflect changes imposed by my buttons; this seems to work now.
